### PR TITLE
Drop concrete class codegen

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,8 +49,8 @@ http_file(
     # In some way, it'd be nicer to make use of https://github.com/JasonSteving99/claro-lang/releases/latest/download/..
     # instead of naming the release explicitly. However, this would make it impossible to cherrypick an old version and
     # rebuild without manual work.
-    sha256 = "c2bba898422de5f4a47dd023fe378fb816095d6c7a30dbaf9db5e04fabad990f",
-    url = "https://github.com/JasonSteving99/claro-lang/releases/download/v0.1.413/claro-cli-install.tar.gz",
+    sha256 = "f1c2911ddd333f96970a23ca4c205afa9f209bc41bd70c4e8386efc6bcda15f3",
+    url = "https://github.com/JasonSteving99/claro-lang/releases/download/v0.1.408/claro-cli-install.tar.gz",
 )
 
 # ClaroDocs is built atop Google's Closure Templates in order to ensure that I'm not generating unsafe html since the

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,6 +40,19 @@ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_
 rules_proto_dependencies()
 rules_proto_toolchains()
 
+# Claro's going to require bootstrapping for at least Dep Module Monomorphization, and in the future will ideally
+# iteratively be migrated from an all-Java implementation, to an implementation that uses progressively more Claro. As
+# such, a "bootstrapping compiler", defined via a prior release, will be necessary in order to prevent a circular dep
+# in Claro's Bazel build which would fail to build.
+http_file(
+    name = "bootstrapping_claro_compiler_tarfile",
+    # In some way, it'd be nicer to make use of https://github.com/JasonSteving99/claro-lang/releases/latest/download/..
+    # instead of naming the release explicitly. However, this would make it impossible to cherrypick an old version and
+    # rebuild without manual work.
+    sha256 = "c2bba898422de5f4a47dd023fe378fb816095d6c7a30dbaf9db5e04fabad990f",
+    url = "https://github.com/JasonSteving99/claro-lang/releases/download/v0.1.413/claro-cli-install.tar.gz",
+)
+
 # ClaroDocs is built atop Google's Closure Templates in order to ensure that I'm not generating unsafe html since the
 # intention is for users to be able to trust and host ClaroDocs themselves (particularly relevant since ClaroDocs
 # automatically generate inlined docs for all of the binaries dependencies, whether first or 3rd party).

--- a/examples/claro_programs/module_system/TestIndirection.claro_module_api
+++ b/examples/claro_programs/module_system/TestIndirection.claro_module_api
@@ -3,6 +3,5 @@
 function add(lhs: int, rhs: int) -> Addition::IntAlias;
 function addFancyInt(lhs: int, rhs: int) -> Addition::FancyInt;
 
-provider getSomeStruct() -> struct {x: int, nested: struct {y: int}};
 
 newtype List<T> : [T]

--- a/examples/claro_programs/module_system/indirect_addition.claro
+++ b/examples/claro_programs/module_system/indirect_addition.claro
@@ -11,7 +11,3 @@ function add(lhs: int, rhs: int) -> Addition::IntAlias {
 function addFancyInt(lhs: int, rhs: int) -> Addition::FancyInt {
   return Addition::getFancyInt(lhs + rhs);
 }
-
-provider getSomeStruct() -> struct {x: int, nested: struct {y: int}} {
-  return {x = 10, nested = {y = 100}};
-}

--- a/examples/claro_programs/module_system/test_main.claro
+++ b/examples/claro_programs/module_system/test_main.claro
@@ -46,10 +46,3 @@ print(TestDep::immutableListHead(opaqueImmutableList));
 #print(unwrap(opaqueImmutableList));
 # And, you cannot instantiate them. Uncomment for compile-time error.
 #print(TestDep::ImmutableList([1,2,3]));
-
-print("----------------------------------------------------------------------------------------------------");
-var someStruct = TestDep2::getSomeStruct();
-print(someStruct);
-type(someStruct);
-someStruct = {x = 200, nested = someStruct.nested};
-print(someStruct);

--- a/non_module_deps.bzl
+++ b/non_module_deps.bzl
@@ -20,8 +20,8 @@ def _non_module_deps_impl(ctx):
   )
   http_file(
     name = "bootstrapping_claro_compiler_tarfile",
-    sha256 = "c2bba898422de5f4a47dd023fe378fb816095d6c7a30dbaf9db5e04fabad990f",
-    url = "https://github.com/JasonSteving99/claro-lang/releases/download/v0.1.413/claro-cli-install.tar.gz",
+    sha256 = "f1c2911ddd333f96970a23ca4c205afa9f209bc41bd70c4e8386efc6bcda15f3",
+    url = "https://github.com/JasonSteving99/claro-lang/releases/download/v0.1.408/claro-cli-install.tar.gz",
   )
   # ClaroDocs is built atop Google's Closure Templates in order to ensure that I'm not generating unsafe html since the
   # intention is for users to be able to trust and host ClaroDocs themselves (particularly relevant since ClaroDocs

--- a/non_module_deps.bzl
+++ b/non_module_deps.bzl
@@ -20,8 +20,8 @@ def _non_module_deps_impl(ctx):
   )
   http_file(
     name = "bootstrapping_claro_compiler_tarfile",
-    sha256 = "a85c20ae29c8c7199ed1e84f5ccd4aa62b411b7de37826e4044b0d9e4f17b31f",
-    url = "https://github.com/JasonSteving99/claro-lang/releases/download/v0.1.414/claro-cli-install.tar.gz",
+    sha256 = "c2bba898422de5f4a47dd023fe378fb816095d6c7a30dbaf9db5e04fabad990f",
+    url = "https://github.com/JasonSteving99/claro-lang/releases/download/v0.1.413/claro-cli-install.tar.gz",
   )
   # ClaroDocs is built atop Google's Closure Templates in order to ensure that I'm not generating unsafe html since the
   # intention is for users to be able to trust and host ClaroDocs themselves (particularly relevant since ClaroDocs

--- a/non_module_deps.bzl
+++ b/non_module_deps.bzl
@@ -20,8 +20,8 @@ def _non_module_deps_impl(ctx):
   )
   http_file(
     name = "bootstrapping_claro_compiler_tarfile",
-    sha256 = "b31f095e6c7d41c1435eefc89d608a73ac26f848ad8e2e2c900dd1c01cf255a8",
-    url = "https://github.com/JasonSteving99/claro-lang/releases/download/v0.1.415/claro-cli-install.tar.gz",
+    sha256 = "a85c20ae29c8c7199ed1e84f5ccd4aa62b411b7de37826e4044b0d9e4f17b31f",
+    url = "https://github.com/JasonSteving99/claro-lang/releases/download/v0.1.414/claro-cli-install.tar.gz",
   )
   # ClaroDocs is built atop Google's Closure Templates in order to ensure that I'm not generating unsafe html since the
   # intention is for users to be able to trust and host ClaroDocs themselves (particularly relevant since ClaroDocs

--- a/src/java/com/claro/claro_build_rules_internal.bzl
+++ b/src/java/com/claro/claro_build_rules_internal.bzl
@@ -64,6 +64,7 @@ CLARO_BUILTIN_JAVA_DEPS = [
     "@claro-lang//src/java/com/claro/intermediate_representation/types/impls/builtins_impls/collections:collections_impls",
     "@claro-lang//src/java/com/claro/intermediate_representation/types/impls/builtins_impls/futures:ClaroFuture",
     "@claro-lang//src/java/com/claro/intermediate_representation/types/impls/builtins_impls/procedures",
+    "@claro-lang//src/java/com/claro/intermediate_representation/types/impls/builtins_impls/structs",
     "@claro-lang//src/java/com/claro/intermediate_representation/types/impls/user_defined_impls:user_defined_impls",
     "@claro-lang//src/java/com/claro/intermediate_representation/types:base_type",
     "@claro-lang//src/java/com/claro/intermediate_representation/types:concrete_type",

--- a/src/java/com/claro/compiler_backends/java_source/JavaSourceCompilerBackend.java
+++ b/src/java/com/claro/compiler_backends/java_source/JavaSourceCompilerBackend.java
@@ -693,8 +693,7 @@ public class JavaSourceCompilerBackend implements CompilerBackend {
         .addAllConcreteTypeParams(
             orderedConcreteTypeParams.stream().map(Type::toProto).collect(Collectors.toList()))
         .addAllUserDefinedTypeConcreteTypeParamsMetadata(
-            orderedConcreteTypeParams.stream()
-                .flatMap(t -> Types.collectAllReferencedUserDefinedTypes(t, ImmutableSet.builder()).build().stream())
+            orderedConcreteTypeParams.stream().filter(t -> t instanceof Types.UserDefinedType)
                 .map(t -> {
                   Types.UserDefinedType userDefinedType = (Types.UserDefinedType) t;
                   String disambiguatedIdentifier =

--- a/src/java/com/claro/compiler_backends/java_source/monomorphization/BUILD
+++ b/src/java/com/claro/compiler_backends/java_source/monomorphization/BUILD
@@ -11,7 +11,6 @@ java_library(
         "//src/java/com/claro/compiler_backends/java_source/monomorphization/ipc_coordinator:monomorphization_ipc_coordinator_compiled_claro_module_java_lib",
         "//src/java/com/claro/compiler_backends/java_source/monomorphization/ipc_coordinator:subprocess_registration",
         "//src/java/com/claro/compiler_backends/java_source/monomorphization/ipc_protos:ipc_messages_java_proto",
-        "//src/java/com/claro/intermediate_representation/types:types",
         "//src/java/com/claro/module_system/module_serialization/proto/claro_types:claro_types_java_proto",
         "//src/java/com/claro/runtime_utilities",
         "//src/java/com/claro/runtime_utilities/http",

--- a/src/java/com/claro/compiler_backends/java_source/monomorphization/MonomorphizationCoordinator.java
+++ b/src/java/com/claro/compiler_backends/java_source/monomorphization/MonomorphizationCoordinator.java
@@ -3,7 +3,6 @@ package com.claro.compiler_backends.java_source.monomorphization;
 import com.claro.compiler_backends.java_source.monomorphization.ipc_coordinator.SubprocessRegistration;
 import com.claro.compiler_backends.java_source.monomorphization.proto.ipc_protos.IPCMessages;
 import com.claro.compiler_backends.java_source.monomorphization.proto.ipc_protos.IPCMessages.MonomorphizationRequest;
-import com.claro.intermediate_representation.types.Types;
 import com.claro.runtime_utilities.ClaroRuntimeUtilities;
 import com.claro.runtime_utilities.http.$ClaroHttpServer;
 import com.claro.runtime_utilities.http.$HttpUtil;
@@ -24,7 +23,6 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import static claro.lang.src$java$com$claro$compiler_backends$java_source$monomorphization$ipc$main_compilation_unit_monomorphization_ipc.DepModuleMonomorphizationService;
@@ -114,21 +112,6 @@ public class MonomorphizationCoordinator {
         // Cache the result so that we can avoid duplicate calls in the future.
         monomorphizationsByModuleAndRequestCache.put(
             module, monomorphization.getMonomorphizationRequest(), monomorphization.getMonomorphizationCodegen());
-        // Update the set of referenced types that will need a custom Java class codegen'd for them.
-        monomorphizationRes.getReferencedTypesToCodegenCustomClassesForList().forEach(
-            t -> {
-              Types.StructType structType = (Types.StructType) Types.parseTypeProto(t.getType());
-              structType.autoValueIgnored_concreteTypeMappings =
-                  Optional.of(t.getConcreteTypeMappingsList().stream().collect(ImmutableMap.toImmutableMap(
-                      m -> Types.parseTypeProto(m.getGenericType()),
-                      m -> Types.parseTypeProto(m.getConcreteType())
-                  )));
-              Types.StructType.allReferencedConcreteStructTypesToOptionalGenericTypeMappings.put(
-                  t.getCustomClassName(),
-                  structType
-              );
-            }
-        );
       }
       // Handle any transitive dep module monomorphizations that were requested by the dep module subprocess.
       for (IPCMessages.MonomorphizationResponse.TransitiveDepModuleMonomorphizationRequest

--- a/src/java/com/claro/compiler_backends/java_source/monomorphization/ipc/MonomorphizationRequestProcessing.java
+++ b/src/java/com/claro/compiler_backends/java_source/monomorphization/ipc/MonomorphizationRequestProcessing.java
@@ -65,24 +65,7 @@ public class MonomorphizationRequestProcessing {
                                    .setMonomorphizationRequest(e.getValue())
                                    .build())
                       .collect(Collectors.toList()))
-              .addAllReferencedTypesToCodegenCustomClassesFor(
-                  Types.StructType.allReferencedConcreteStructTypesToOptionalGenericTypeMappings.entrySet().stream()
-                      .map(e -> IPCMessages.MonomorphizationResponse.TypeToCodegenCustomClassFor.newBuilder()
-                          .setCustomClassName(e.getKey())
-                          .setType(e.getValue().toProto())
-                          .addAllConcreteTypeMappings(
-                              e.getValue().autoValueIgnored_concreteTypeMappings
-                                  .map(m -> m.entrySet().stream()
-                                      .map(mapping ->
-                                               IPCMessages.MonomorphizationResponse.TypeToCodegenCustomClassFor.TypeMapping.newBuilder()
-                                                   .setGenericType(mapping.getKey().toProto())
-                                                   .setConcreteType(mapping.getValue().toProto())
-                                                   .build()
-                                      ).collect(ImmutableList.toImmutableList()))
-                                  .orElse(ImmutableList.of())
-                          ).build())
-                      .collect(ImmutableList.toImmutableList())
-              ).build().toByteArray());
+              .build().toByteArray());
     } catch (Exception e) {
       // If there's any sort of exception during the actual compilation logic itself, I really need some way to diagnose
       // that in the main coordinator process as debugging the dep module processes is a painful process. So, instead,

--- a/src/java/com/claro/compiler_backends/java_source/monomorphization/ipc_protos/ipc_messages.proto
+++ b/src/java/com/claro/compiler_backends/java_source/monomorphization/ipc_protos/ipc_messages.proto
@@ -45,17 +45,6 @@ message MonomorphizationResponse {
     string unique_module_name = 1;
     MonomorphizationRequest monomorphization_request = 2;
   }
-  message TypeToCodegenCustomClassFor {
-    message TypeMapping {
-      claro.module_system.module_serialization.claro_types.TypeProto generic_type = 1;
-      claro.module_system.module_serialization.claro_types.TypeProto concrete_type = 2;
-    }
-    string custom_class_name = 1;
-    claro.module_system.module_serialization.claro_types.TypeProto type = 2;
-    // This is the mapping of any potential generic type params referenced in the given type so that they can be mapped
-    // to their concrete types to codegen class field types as necessary.
-    repeated TypeMapping concrete_type_mappings = 3;
-  }
   // The actual codegen'd Java-source strings for the requested monomorphization as well as any other local, generic
   // procedure monomorphizations that were triggered by monomorphization of the requested procedure (this can happen
   // when a generic procedure calls another generic procedure ad infinitum).
@@ -73,17 +62,6 @@ message MonomorphizationResponse {
   // MonomorphizationResponse, leaving everything else unset. The coordinator should then check for errors before
   // proceeding.
   string optional_error_message = 3;
-
-  // Because monomorphizations may very well reference totally new types internally that never even get referenced
-  // anywhere else, we can't blindly rely on the codegen for the procedure on its own right without potentially
-  // generating the corresponding classes for those types. E.g.:
-  //    consumer foo<A, B>(a: A, b: B) {
-  //      print({fieldA = a, fieldB = b}); # Super contrived, but this type is likely only ever referenced here.
-  //    }
-  // So, to ensure that the generated Java compiles, the calling compilation unit must do the codegen for any types
-  // referenced during dep module monomorphization (unless for some reason the type(s) have already been verified to
-  // have been codegen'd).
-  repeated TypeToCodegenCustomClassFor referenced_types_to_codegen_custom_classes_for = 4;
 }
 
 

--- a/src/java/com/claro/intermediate_representation/Node.java
+++ b/src/java/com/claro/intermediate_representation/Node.java
@@ -24,10 +24,7 @@ public abstract class Node {
   // declared or not.
   public abstract GeneratedJavaSource generateJavaSourceOutput(ScopedHeap scopedHeap);
 
-  // TODO(steving) Rip the interpreter out of the compiler. This is defunct and unsupported and just extra noise.
-  public Object generateInterpretedOutput(ScopedHeap scopedHeap) {
-    throw new RuntimeException("Internal Compiler Error! The interpreted backend is no longer supported!");
-  }
+  public abstract Object generateInterpretedOutput(ScopedHeap scopedHeap);
 
   @AutoValue
   public abstract static class GeneratedJavaSource {

--- a/src/java/com/claro/intermediate_representation/ProgramNode.java
+++ b/src/java/com/claro/intermediate_representation/ProgramNode.java
@@ -874,6 +874,7 @@ public class ProgramNode {
             "import com.claro.intermediate_representation.types.impls.builtins_impls.procedures.ClaroConsumerFunction;\n" +
             "import com.claro.intermediate_representation.types.impls.builtins_impls.procedures.ClaroFunction;\n" +
             "import com.claro.intermediate_representation.types.impls.builtins_impls.procedures.ClaroProviderFunction;\n" +
+            "import com.claro.intermediate_representation.types.impls.builtins_impls.structs.ClaroStruct;\n" +
             "import com.claro.intermediate_representation.types.impls.user_defined_impls.$UserDefinedType;\n" +
             "import com.claro.intermediate_representation.types.impls.user_defined_impls.ClaroUserDefinedTypeImplementation;\n" +
             "import com.claro.runtime_utilities.ClaroRuntimeUtilities;\n" +

--- a/src/java/com/claro/intermediate_representation/ProgramNode.java
+++ b/src/java/com/claro/intermediate_representation/ProgramNode.java
@@ -310,7 +310,7 @@ public class ProgramNode {
         MonomorphizationCoordinator.shutdownDepModuleMonomorphization();
       }
       res.append("\n// Semantically Polymorphic Builtin Type Concrete Monomorphizations Generated Below:\n");
-      for (Types.StructType s : Types.StructType.allReferencedConcreteStructTypesToOptionalGenericTypeMappings.values()) {
+      for (Types.StructType s : Types.StructType.allReferencedConcreteStructTypesToOptionalGenericTypeMappings.keySet()) {
         res.append(s.getConcreteJavaClassRepresentation());
       }
     }

--- a/src/java/com/claro/intermediate_representation/ProgramNode.java
+++ b/src/java/com/claro/intermediate_representation/ProgramNode.java
@@ -309,10 +309,6 @@ public class ProgramNode {
         // Cleanup any threads or subprocesses that got started up by monomorphization.
         MonomorphizationCoordinator.shutdownDepModuleMonomorphization();
       }
-      res.append("\n// Semantically Polymorphic Builtin Type Concrete Monomorphizations Generated Below:\n");
-      for (Types.StructType s : Types.StructType.allReferencedConcreteStructTypesToOptionalGenericTypeMappings.keySet()) {
-        res.append(s.getConcreteJavaClassRepresentation());
-      }
     }
 
     // Just for completeness sake, we'll want to exit this global scope as well just in case there are important checks

--- a/src/java/com/claro/intermediate_representation/expressions/BUILD
+++ b/src/java/com/claro/intermediate_representation/expressions/BUILD
@@ -39,6 +39,7 @@ java_library(
         "//src/java/com/claro/intermediate_representation/types/impls/builtins_impls:builtins_impls",
         "//src/java/com/claro/intermediate_representation/types/impls/builtins_impls/collections:collection_interface",
         "//src/java/com/claro/intermediate_representation/types/impls/builtins_impls/collections:collections_impls",
+        "//src/java/com/claro/intermediate_representation/types/impls/builtins_impls/structs",
         "//src/java/com/claro/intermediate_representation/types/impls/user_defined_impls",
         "//src/java/com/claro/intermediate_representation/types:claro_type_exception",
         "//src/java/com/claro/intermediate_representation/types:supports_mutable_variant",

--- a/src/java/com/claro/intermediate_representation/expressions/CopyExpr.java
+++ b/src/java/com/claro/intermediate_representation/expressions/CopyExpr.java
@@ -218,74 +218,62 @@ public class CopyExpr extends Expr {
                                     .append(") ")
                                     .append(copiedTupleValSyntheticVar)
                                     .append(copiedExprType.baseType().equals(BaseType.TUPLE)
-                                            ? ".getElement(" + i + ")"
-                                            : "." + ((Types.StructType) copiedExprType).getFieldNames().get(i))
+                                            ? ".getElement("
+                                            : ".values[")
+                                    .append(i)
+                                    .append(copiedExprType.baseType().equals(BaseType.TUPLE) ? ")" : "]")
                                     .append(")")),
                             currElementType,
                             currCoercedElementType,
                             nestingLevel + 1
                         );
                       }).collect(ImmutableList.toImmutableList());
+          res = GeneratedJavaSource.forJavaSourceBody(
+              new StringBuilder("new Claro")
+                  .append(coercedType.baseType().equals(BaseType.TUPLE) ? "Tuple" : "Struct")
+                  .append("(")
+                  .append(coercedType.getJavaSourceClaroType())
+                  .append(", ")
+          );
           if (optionalElementCopyCodegens.stream().noneMatch(Optional::isPresent)
-              && !((SupportsMutableVariant<?>) copiedExprType).isMutable()
-              && !((SupportsMutableVariant<?>) coercedType).isMutable()) {
+              && !((SupportsMutableVariant<?>) copiedExprType).isMutable() &&
+              !((SupportsMutableVariant<?>) coercedType).isMutable()) {
             return Optional.empty();
           }
           // Here we've found some elements that aren't deeply-immutable, so we need to copy them.
-          switch (coercedType.baseType()) {
-            case TUPLE:
-              res = GeneratedJavaSource.forJavaSourceBody(
-                  new StringBuilder("new ClaroTuple(").append(coercedType.getJavaSourceClaroType()).append(", "));
-              res.javaSourceBody()
-                  .append("((Function<")
-                  .append(copiedExprType.getJavaSourceType())
-                  .append(", Object[]>) ")
-                  .append(copiedTupleValSyntheticVar)
-                  .append(" -> new Object[] {")
-                  .append(
-                      IntStream.range(0, copiedExprType.parameterizedTypeArgs().size()).boxed()
-                          .map(i -> optionalElementCopyCodegens.get(i)
+          res.javaSourceBody()
+              .append("((Function<")
+              .append(copiedExprType.getJavaSourceType())
+              .append(", Object[]>) ")
+              .append(copiedTupleValSyntheticVar)
+              .append(" -> new Object[] {")
+              .append(
+                  IntStream.range(
+                          0,
+                          copiedExprType.baseType().equals(BaseType.TUPLE)
+                          ? copiedExprType.parameterizedTypeArgs().size()
+                          : ((Types.StructType) copiedExprType).getFieldTypes().size()
+                      )
+                      .boxed()
+                      .map(
+                          i -> optionalElementCopyCodegens.get(i)
                               .map(GeneratedJavaSource::javaSourceBody)
-                              .orElseGet(() -> new StringBuilder(
-                                  String.format("%s.getElement(%s)", copiedTupleValSyntheticVar, i)))
-                          ).collect(Collectors.joining(", ")))
-                  .append("}).apply(");
-              copiedExprJavaSource.javaSourceBody()
-                  .append("))");
-              res = res.createMerged(copiedExprJavaSource);
-              break;
-            case STRUCT:
-              Types.StructType copiedStructType = (Types.StructType) copiedExprType;
-              String coercedStructJavaSourceType = coercedType.getJavaSourceType();
-              res = GeneratedJavaSource.forJavaSourceBody(
-                  new StringBuilder("((Function<")
-                      .append(copiedExprType.getJavaSourceType())
-                      .append(", ")
-                      .append(coercedStructJavaSourceType)
-                      .append(">) ")
-                      .append(copiedTupleValSyntheticVar)
-                      .append(" -> new ")
-                      .append(coercedStructJavaSourceType).append("(")
-                      .append(
-                          IntStream.range(0, copiedStructType.getFieldNames().size()).boxed()
-                              .map(i -> optionalElementCopyCodegens.get(i)
-                                  .map(GeneratedJavaSource::javaSourceBody)
-                                  .orElseGet(() -> new StringBuilder(
-                                      String.format(
-                                          "%s.%s",
-                                          copiedTupleValSyntheticVar,
-                                          ((Types.StructType) copiedExprType).getFieldNames().get(i)
-                                      )))
-                              ).collect(Collectors.joining(", ")))
-                      .append(")).apply(")
-              );
-              copiedExprJavaSource.javaSourceBody()
-                  .append(")");
-              res = res.createMerged(copiedExprJavaSource);
-              break;
-            default:
-              throw new RuntimeException("Internal Compiler Error! Expected Tuple/Struct, got: " + coercedType);
-          }
+                              .orElseGet(() ->
+                                             new StringBuilder(
+                                                 String.format(
+                                                     copiedExprType.baseType().equals(BaseType.TUPLE)
+                                                     ? "%s.getElement(%s)"
+                                                     : "%s.values[%s]",
+                                                     copiedTupleValSyntheticVar,
+                                                     i
+                                                 )))
+                      )
+                      .collect(Collectors.joining(", "))
+              )
+              .append("}).apply(");
+          copiedExprJavaSource.javaSourceBody()
+              .append("))");
+          res = res.createMerged(copiedExprJavaSource);
           return Optional.of(res);
         case USER_DEFINED_TYPE:
           Types.UserDefinedType copiedExprUserDefinedType = (Types.UserDefinedType) copiedExprType;

--- a/src/java/com/claro/intermediate_representation/expressions/FromJsonExpr.java
+++ b/src/java/com/claro/intermediate_representation/expressions/FromJsonExpr.java
@@ -157,15 +157,10 @@ public class FromJsonExpr extends Expr {
     if (!alreadyPeekedType) {
       res.append(GSON_TOKEN).append(" $peeked").append(nestingLevel).append(" = $jsonReader.peek();\n");
     }
-    final ImmutableList<String> errParsedJsonStructTypeAndCodegen =
-        getErrorParsedJson(type, "$jsonReader.getPath()", "$jsonString");
-    final String errParsedJsonStructJavaSourceType = errParsedJsonStructTypeAndCodegen.get(0);
-    final String errorParsedJsonForType = errParsedJsonStructTypeAndCodegen.get(1);
     BiFunction<Type, Boolean, StringBuilder> getFieldParserForType = (fieldType, _alreadyPeeked) ->
         new StringBuilder()
-            .append("((Supplier<$UserDefinedType<")
-            .append(errParsedJsonStructJavaSourceType)
-            .append(">>) () -> {\n\t\t")
+            .append("((Supplier<$UserDefinedType<ClaroStruct>>) () -> {\n")
+            .append("\t\t")
             .append(getParseJSONJavaSource(fieldType, nestingLevel + 1, /*alreadyPeekedType=*/ _alreadyPeeked))
             .append("\t}).get();");
     switch (type.baseType()) {
@@ -173,9 +168,9 @@ public class FromJsonExpr extends Expr {
         if (!alreadyPeekedType) {
           res.append("if (").append(GSON_TOKEN).append(".BOOLEAN.equals($peeked").append(nestingLevel).append(")) {\n");
         }
-        res.append("\treturn ")
-            .append(getSuccessParsedJson(type, "$jsonReader.nextBoolean()", "$jsonString"))
-            .append(";\n");
+        res.append("\treturn ClaroRuntimeUtilities.$getSuccessParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $jsonReader.nextBoolean(), $jsonString);\n");
         if (!alreadyPeekedType) {
           res.append("} ");
         }
@@ -185,13 +180,13 @@ public class FromJsonExpr extends Expr {
           res.append("if (").append(GSON_TOKEN).append(".NUMBER.equals($peeked").append(nestingLevel).append(")) {\n");
         }
         res.append("\ttry {\n")
-            .append("\treturn ")
-            .append(getSuccessParsedJson(type, "$jsonReader.nextInt()", "$jsonString"))
-            .append(";\n")
+            .append("\treturn ClaroRuntimeUtilities.$getSuccessParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $jsonReader.nextInt(), $jsonString);\n")
             .append("\t} catch (java.lang.NumberFormatException e) {\n")
-            .append("\t\treturn ")
-            .append(errorParsedJsonForType)
-            .append(";\n")
+            .append("\t\treturn ClaroRuntimeUtilities.$getErrorParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $jsonReader.getPath(), $jsonString);\n")
             .append("\t}\n");
         if (!alreadyPeekedType) {
           res.append("}");
@@ -202,13 +197,13 @@ public class FromJsonExpr extends Expr {
           res.append("if (").append(GSON_TOKEN).append(".NUMBER.equals($peeked").append(nestingLevel).append(")) {\n");
         }
         res.append("\ttry {\n")
-            .append("\treturn ")
-            .append(getSuccessParsedJson(type, "$jsonReader.nextDouble()", "$jsonString"))
-            .append(";\n")
+            .append("\treturn ClaroRuntimeUtilities.$getSuccessParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $jsonReader.nextDouble(), $jsonString);\n")
             .append("\t} catch (java.lang.NumberFormatException e) {\n")
-            .append("\t\treturn ")
-            .append(errorParsedJsonForType)
-            .append(";\n")
+            .append("\t\treturn ClaroRuntimeUtilities.$getErrorParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(" $jsonReader.getPath(), $jsonString);\n")
             .append("\t}\n");
         if (!alreadyPeekedType) {
           res.append("}");
@@ -218,9 +213,9 @@ public class FromJsonExpr extends Expr {
         if (!alreadyPeekedType) {
           res.append("if (").append(GSON_TOKEN).append(".STRING.equals($peeked").append(nestingLevel).append(")) {\n");
         }
-        res.append("\treturn ")
-            .append(getSuccessParsedJson(type, "$jsonReader.nextString()", "$jsonString"))
-            .append(";\n");
+        res.append("\treturn ClaroRuntimeUtilities.$getSuccessParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $jsonReader.nextString(), $jsonString);\n");
         if (!alreadyPeekedType) {
           res.append("} ");
         }
@@ -236,22 +231,20 @@ public class FromJsonExpr extends Expr {
           // Here it turns out that we actually need to codegen a lookup into the ATOM CACHE of the stdlib module
           // defining this builtin type.
           res.append("\t$jsonReader.nextNull();\n")
-              .append("\treturn ")
+              .append("\treturn ClaroRuntimeUtilities.$getSuccessParsedJson(")
+              .append(type.getJavaSourceClaroType())
+              .append(", ")
               .append(
-                  getSuccessParsedJson(
-                      type,
-                      String.format(
-                          "%s.%s.ATOM_CACHE[%s]",
-                          StdLibModuleRegistry.STDLIB_MODULE_PACKAGE,
+                  String.format(
+                      "%s.%s.ATOM_CACHE[%s]",
+                      StdLibModuleRegistry.STDLIB_MODULE_PACKAGE,
+                      StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR,
+                      InternalStaticStateUtil.AtomDefinition_CACHE_INDEX_BY_MODULE_AND_ATOM_NAME.build().get(
                           StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR,
-                          InternalStaticStateUtil.AtomDefinition_CACHE_INDEX_BY_MODULE_AND_ATOM_NAME.build().get(
-                              StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR,
-                              String.format("Nothing$%s", StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR)
-                          )
-                      ),
-                      "$jsonString"
+                          String.format("Nothing$%s", StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR)
+                      )
                   ))
-              .append(";");
+              .append(", $jsonString);");
           if (!alreadyPeekedType) {
             res.append("} ");
           }
@@ -278,25 +271,21 @@ public class FromJsonExpr extends Expr {
             .append(" = new ClaroList(")
             .append(type.getJavaSourceClaroType())
             .append(");\n")
-            .append("\tfinal Supplier<$UserDefinedType<")
-            .append(errParsedJsonStructJavaSourceType)
-            .append(">> $parseElement")
+            .append("\tfinal Supplier<$UserDefinedType<ClaroStruct>> $parseElement")
             .append(nestingLevel)
             .append(" = () -> {\n")
             .append("\t\t")
             .append(getParseJSONJavaSource(elemType, nestingLevel + 1, /*alreadyPeekedType=*/ false))
             .append("\t};\n")
             .append("\twhile ($jsonReader.hasNext()) {\n")
-            .append("\t\t$UserDefinedType<")
-            .append(errParsedJsonStructJavaSourceType)
-            .append("> $parsedElem")
+            .append("\t\t$UserDefinedType<ClaroStruct> $parsedElem")
             .append(nestingLevel)
             .append(" = $parseElement")
             .append(nestingLevel)
             .append(".get();\n")
             .append("\t\tif ($parsedElem")
             .append(nestingLevel)
-            .append(".wrappedValue.result instanceof $UserDefinedType) { // It's necessarily an Error<string> since Claro can't parse user-defined types from JSON automatically.\n")
+            .append(".wrappedValue.values[0] instanceof $UserDefinedType) { // It's necessarily an Error<string> since Claro can't parse user-defined types from JSON automatically.\n")
             .append("\t\t\treturn $parsedElem")
             .append(nestingLevel)
             .append(";\n")
@@ -307,19 +296,20 @@ public class FromJsonExpr extends Expr {
             .append(elemType.getJavaSourceType())
             .append(") $parsedElem")
             .append(nestingLevel)
-            .append(".wrappedValue.result);\n")
+            .append(".wrappedValue.values[0]);\n")
             .append("\t}\n")
             .append("\t$jsonReader.endArray();\n")
-            .append("\treturn ")
-            .append(getSuccessParsedJson(type, "$listBuilder" + nestingLevel, "$jsonString"))
-            .append(";\n");
+            .append("\treturn ClaroRuntimeUtilities.$getSuccessParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $listBuilder")
+            .append(nestingLevel)
+            .append(", $jsonString);\n");
         if (!alreadyPeekedType) {
           res.append("} ");
         }
         break;
       case STRUCT:
         Types.StructType structType = (Types.StructType) type;
-        String structJavaSourceType = structType.getJavaSourceType();
         if (!alreadyPeekedType) {
           res.append("if (")
               .append(GSON_TOKEN)
@@ -330,62 +320,50 @@ public class FromJsonExpr extends Expr {
         res.append("\t$jsonReader.beginObject();\n")
             // This is a fascinating example of a compiler superpower that the users don't have access to. Here,
             // regardless of whether the struct is being parsed to mutable/immutable, I'm going to modify the
-            // fields because I know that I'm the sole owner of this struct as I, the compiler, just created it.
-            .append("\t")
-            .append(structJavaSourceType)
-            .append(" $structBuilder")
+            // array because I know that I'm the sole owner of this struct as I, the compiler, just created it.
+            .append("\tClaroStruct $structBuilder")
             .append(nestingLevel)
-            .append(" = new ")
-            .append(structJavaSourceType)
-            .append("(")
+            .append(" = new ClaroStruct(")
+            .append(type.getJavaSourceClaroType())
+            .append(", ")
             .append(IntStream.range(0, structType.getFieldTypes().size())
                         .boxed()
-                        .map(i -> "null")
+                        .map(i -> "(Object) null")
                         .collect(Collectors.joining(", ")))
             .append(");\n")
             .append("\twhile ($jsonReader.hasNext()) {\n")
-            .append("\t\t$UserDefinedType<")
-            .append(errParsedJsonStructJavaSourceType)
-            .append("> $parsedField")
+            .append("\t\t$UserDefinedType<ClaroStruct> $parsedField")
             .append(nestingLevel)
             .append(";\n")
             .append("\t\tswitch($jsonReader.nextName()) {\n");
         IntStream.range(0, structType.getFieldTypes().size()).boxed().forEach(
-            i -> {
-              res
-                  .append("\t\t\tcase \"")
-                  .append(structType.getFieldNames().get(i))
-                  .append("\":\n")
-                  .append("\t\t\t\t$parsedField")
-                  .append(nestingLevel)
-                  .append(" = ")
-                  .append(getFieldParserForType.apply(structType.getFieldTypes().get(i), /*_alreadyPeaked=*/ false))
-                  // This is just to save some lines of code, but here I'm going to optimistically put whatever we parsed
-                  // into the struct builder, though we may not end up using it.
-                  .append("\n\t\t\t\t$structBuilder")
-                  .append(nestingLevel)
-                  .append(".")
-                  .append(structType.getFieldNames().get(i))
-                  .append(" = (")
-                  .append(structType.getFieldTypes().get(i).getJavaSourceType());
-              String parsedFieldResult = "$parsedField" + nestingLevel + ".wrappedValue.result";
-              res
-                  .append(") (")
-                  .append(parsedFieldResult)
-                  .append(" instanceof $UserDefinedType ? /*Error*/ null : ")
-                  .append(parsedFieldResult)
-                  .append(");\n")
-                  .append("\t\t\t\tbreak;\n");
-            }
+            i -> res
+                .append("\t\t\tcase \"")
+                .append(structType.getFieldNames().get(i))
+                .append("\":\n")
+                .append("\t\t\t\t$parsedField")
+                .append(nestingLevel)
+                .append(" = ")
+                .append(getFieldParserForType.apply(structType.getFieldTypes().get(i), /*_alreadyPeaked=*/ false))
+                // This is just to save some lines of code, but here I'm going to optimistically put whatever we parsed
+                // into the struct builder, though we may not end up using it.
+                .append("\n\t\t\t\t$structBuilder")
+                .append(nestingLevel)
+                .append(".values[")
+                .append(i)
+                .append("] = $parsedField")
+                .append(nestingLevel)
+                .append(".wrappedValue.values[0];\n")
+                .append("\t\t\t\tbreak;\n")
         );
         res.append("\t\t\tdefault: // This is some unexpected field.\n")
-            .append("\t\t\t\treturn ")
-            .append(errorParsedJsonForType)
-            .append(";\n")
+            .append("\t\t\t\treturn ClaroRuntimeUtilities.$getErrorParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $jsonReader.getPath(), $jsonString);\n")
             .append("\t\t}\n")
             .append("\t\tif ($parsedField")
             .append(nestingLevel)
-            .append(".wrappedValue.result instanceof $UserDefinedType) { // It's necessarily an Error<string> since Claro can't parse user-defined types from JSON automatically.\n")
+            .append(".wrappedValue.values[0] instanceof $UserDefinedType) { // It's necessarily an Error<string> since Claro can't parse user-defined types from JSON automatically.\n")
             .append("\t\t\treturn $parsedField")
             .append(nestingLevel)
             .append(";\n")
@@ -395,13 +373,22 @@ public class FromJsonExpr extends Expr {
             // Make sure that we validate that *all* required fields were actually set, otherwise the json parsing is
             // considered a failure. Even if the missing field types were `oneof<..., Nothing>`, Nothing only
             // maps to `null` in the JSON representation, a missing field is an error, not auto-coerced to null.
-            .append(
-                structType.getFieldNames().stream()
-                    .map(n -> String.format("\tif ($structBuilder%s.%s == null) { return %s; }", nestingLevel, n, errorParsedJsonForType))
-                    .collect(Collectors.joining("\n")))
-            .append("\n\treturn ")
-            .append(getSuccessParsedJson(type, "$structBuilder" + nestingLevel, "$jsonString"))
-            .append(";\n");
+            .append("\tfor (int $i = 0; $i < ")
+            .append(structType.getFieldNames().size())
+            .append("; ++$i) {\n")
+            .append("\t\tif ($structBuilder")
+            .append(nestingLevel)
+            .append(".values[$i] == null) {\n")
+            .append("\t\t\treturn ClaroRuntimeUtilities.$getErrorParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $jsonReader.getPath(), $jsonString);\n")
+            .append("\t\t}")
+            .append("\t}")
+            .append("\treturn ClaroRuntimeUtilities.$getSuccessParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $structBuilder")
+            .append(nestingLevel)
+            .append(", $jsonString);\n");
         if (!alreadyPeekedType) {
           res.append("} ");
         }
@@ -424,9 +411,7 @@ public class FromJsonExpr extends Expr {
             .append(" = new ClaroMap(")
             .append(type.getJavaSourceClaroType())
             .append(");\n")
-            .append("\tfinal Supplier<$UserDefinedType<")
-            .append(errParsedJsonStructJavaSourceType)
-            .append(">> $parseElement")
+            .append("\tfinal Supplier<$UserDefinedType<ClaroStruct>> $parseElement")
             .append(nestingLevel)
             .append(" = () -> {\n")
             .append("\t\t")
@@ -439,16 +424,14 @@ public class FromJsonExpr extends Expr {
             .append("\t\tString $key")
             .append(nestingLevel)
             .append(" = $jsonReader.nextName();\n")
-            .append("\t\t$UserDefinedType<")
-            .append(errParsedJsonStructJavaSourceType)
-            .append("> $parsedElem")
+            .append("\t\t$UserDefinedType<ClaroStruct> $parsedElem")
             .append(nestingLevel)
             .append(" = $parseElement")
             .append(nestingLevel)
             .append(".get();\n")
             .append("\t\tif ($parsedElem")
             .append(nestingLevel)
-            .append(".wrappedValue.result instanceof $UserDefinedType) { // It's necessarily an Error<string> since Claro can't parse user-defined types from JSON automatically.\n")
+            .append(".wrappedValue.values[0] instanceof $UserDefinedType) { // It's necessarily an Error<string> since Claro can't parse user-defined types from JSON automatically.\n")
             .append("\t\t\treturn $parsedElem")
             .append(nestingLevel)
             .append(";\n")
@@ -461,12 +444,14 @@ public class FromJsonExpr extends Expr {
             .append(mapType.parameterizedTypeArgs().get(Types.MapType.PARAMETERIZED_TYPE_VALUES).getJavaSourceType())
             .append(") $parsedElem")
             .append(nestingLevel)
-            .append(".wrappedValue.result);\n")
+            .append(".wrappedValue.values[0]);\n")
             .append("\t}\n")
             .append("\t$jsonReader.endObject();\n")
-            .append("\treturn ")
-            .append(getSuccessParsedJson(type, "$mapBuilder" + nestingLevel, "$jsonString"))
-            .append(";\n");
+            .append("\treturn ClaroRuntimeUtilities.$getSuccessParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $mapBuilder")
+            .append(nestingLevel)
+            .append(", $jsonString);\n");
         if (!alreadyPeekedType) {
           res.append("} ");
         }
@@ -475,11 +460,8 @@ public class FromJsonExpr extends Expr {
         // Claro can support a very limited lookahead for parsing oneofs. Here we'll assume that validation has already
         // completed so we know that this oneof's variants can be disambiguated with a single peek().
         Types.OneofType oneofType = (Types.OneofType) type;
-        res.append("\t$UserDefinedType<")
-            .append(errParsedJsonStructJavaSourceType)
-            .append("> $parsedOneof")
-            .append(nestingLevel).append(";\n")
-          .append("\tswitch($peeked").append(nestingLevel).append(") {\n");
+        res.append("\t$UserDefinedType<ClaroStruct> $parsedOneof").append(nestingLevel).append(";\n")
+            .append("\tswitch($peeked").append(nestingLevel).append(") {\n");
         IntStream.range(0, oneofType.getVariantTypes().size()).boxed().forEach(
             i -> {
               res.append("\t\tcase ");
@@ -518,111 +500,35 @@ public class FromJsonExpr extends Expr {
             }
         );
         res.append("\t\tdefault: // This is some unexpected field.\n")
-            .append("\t\t\treturn ")
-            .append(errorParsedJsonForType)
-            .append(";\n")
+            .append("\t\t\treturn ClaroRuntimeUtilities.$getErrorParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $jsonReader.getPath(), $jsonString);\n")
             .append("\t}\n")
             .append("\tif ($parsedOneof")
             .append(nestingLevel)
-            .append(".wrappedValue.result instanceof $UserDefinedType) { // It's necessarily an Error<string> since Claro can't parse user-defined types from JSON automatically.\n")
+            .append(".wrappedValue.values[0] instanceof $UserDefinedType) { // It's necessarily an Error<string> since Claro can't parse user-defined types from JSON automatically.\n")
             .append("\t\treturn $parsedOneof")
             .append(nestingLevel)
             .append(";\n")
             .append("\t} else {\n")
-            .append("\t\treturn ")
-            .append(getSuccessParsedJson(type, "$parsedOneof" + nestingLevel + ".wrappedValue.result", "$jsonString"))
-            .append(";\n")
+            .append("\t\treturn ClaroRuntimeUtilities.$getSuccessParsedJson(")
+            .append(type.getJavaSourceClaroType())
+            .append(", $parsedOneof")
+            .append(nestingLevel)
+            .append(".wrappedValue.values[0], $jsonString);\n")
             .append("\t} ");
         break;
       default:
         throw new RuntimeException("Internal Compiler Error: Should be unreachable! " + type);
     }
     if (!alreadyPeekedType && !type.baseType().equals(BaseType.ONEOF)) {
-      res.append("else { $jsonReader.skipValue(); return ")
-          .append(errorParsedJsonForType)
-          .append("; }\n");
+      res.append("else { $jsonReader.skipValue(); return ClaroRuntimeUtilities.$getErrorParsedJson(")
+          .append(type.getJavaSourceClaroType())
+          .append(", $jsonReader.getPath(), $jsonString); }\n");
     }
-    return res.append("} catch (java.io.IOException e) {\n\treturn ")
-        .append(errorParsedJsonForType)
-        .append("; }\n");
-  }
-
-  private static ImmutableList<String> getErrorParsedJson(Type targetType, String jsonPathError, String jsonString) {
-    final Types.StructType parsedJsonStructType =
-        Types.StructType.forFieldTypes(
-            ImmutableList.of("result", "rawJson"),
-            ImmutableList.of(
-                Types.OneofType.forVariantTypes(
-                    ImmutableList.of(
-                        targetType,
-                        Types.UserDefinedType.forTypeNameAndParameterizedTypes(
-                            "Error",
-                            /*definingModuleDisambiguator=*/StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR,
-                            ImmutableList.of(Types.STRING)
-                        )
-                    )
-                ),
-                Types.STRING
-            ),
-            /*isMutable=*/false
-        );
-    String parsedJsonStructJavaSourceType = parsedJsonStructType.getJavaSourceType();
-    return ImmutableList.of(
-        parsedJsonStructJavaSourceType,
-        "new $UserDefinedType<>(\"ParsedJson\", \"" +
-        StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR +
-        "\", ImmutableList.of(" +
-        targetType.getJavaSourceClaroType() +
-        "), " +
-        parsedJsonStructType.getJavaSourceClaroType() +
-        ", new " +
-        parsedJsonStructJavaSourceType +
-        "(new $UserDefinedType<>(\"Error\", \"" +
-        StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR +
-        "\", ImmutableList.of(Types.STRING), Types.STRING, \"" +
-        "Given JSON string did not match the asserted target type definition.\\n\\tExpected:\\n\\t\\t" +
-        targetType +
-        "\\n\\tAt JsonPath:\\n\\t\\t\" + " +
-        jsonPathError +
-        "), " +
-        jsonString +
-        "))"
-    );
-  }
-
-  private static String getSuccessParsedJson(Type targetType, String parsedRes, String jsonString) {
-    final Types.StructType parsedJsonStructType =
-        Types.StructType.forFieldTypes(
-            ImmutableList.of("result", "rawJson"),
-            ImmutableList.of(
-                Types.OneofType.forVariantTypes(
-                    ImmutableList.of(
-                        targetType,
-                        Types.UserDefinedType.forTypeNameAndParameterizedTypes(
-                            "Error",
-                            /*definingModuleDisambiguator=*/StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR,
-                            ImmutableList.of(Types.STRING)
-                        )
-                    )
-                ),
-                Types.STRING
-            ),
-            /*isMutable=*/false
-        );
-    String parsedJsonStructJavaSourceType = parsedJsonStructType.getJavaSourceType();
-    return "new $UserDefinedType<>(\"ParsedJson\", \"" +
-           StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR +
-           "\", ImmutableList.of(" +
-           targetType.getJavaSourceClaroType() +
-           "), " +
-           parsedJsonStructType.getJavaSourceClaroType() +
-           ", new " +
-           parsedJsonStructJavaSourceType +
-           "(" +
-           parsedRes +
-           ", " +
-           jsonString +
-           "))";
+    return res.append("} catch (java.io.IOException e) {\n\treturn ClaroRuntimeUtilities.$getErrorParsedJson(")
+        .append(type.getJavaSourceClaroType())
+        .append(", $jsonReader.getPath(), $jsonString); }\n");
   }
 
   @Override

--- a/src/java/com/claro/intermediate_representation/expressions/StructExpr.java
+++ b/src/java/com/claro/intermediate_representation/expressions/StructExpr.java
@@ -95,8 +95,10 @@ public class StructExpr extends Expr {
     AtomicReference<GeneratedJavaSource> structValsGenJavaSource =
         new AtomicReference<>(GeneratedJavaSource.forJavaSourceBody(new StringBuilder()));
 
-    StringBuilder resJavaSourceBody = new StringBuilder("new ");
-    resJavaSourceBody.append(this.type.getJavaSourceType()).append("(");
+    StringBuilder resJavaSourceBody = new StringBuilder();
+    resJavaSourceBody.append("new ClaroStruct(");
+    resJavaSourceBody.append(this.type.getJavaSourceClaroType());
+    resJavaSourceBody.append(", ");
     resJavaSourceBody.append(
         this.fieldValues.stream()
             .map(expr -> {

--- a/src/java/com/claro/intermediate_representation/expressions/StructExpr.java
+++ b/src/java/com/claro/intermediate_representation/expressions/StructExpr.java
@@ -2,6 +2,7 @@ package com.claro.intermediate_representation.expressions;
 
 import com.claro.compiler_backends.interpreted.ScopedHeap;
 import com.claro.intermediate_representation.types.*;
+import com.claro.intermediate_representation.types.impls.builtins_impls.structs.ClaroStruct;
 import com.google.common.collect.ImmutableList;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -113,5 +114,16 @@ public class StructExpr extends Expr {
 
     return GeneratedJavaSource.forJavaSourceBody(resJavaSourceBody)
         .createMerged(structValsGenJavaSource.get());
+  }
+
+  @Override
+  public Object generateInterpretedOutput(ScopedHeap scopedHeap) {
+    return new ClaroStruct(
+        type,
+        this.fieldValues.stream()
+            .map(expr -> expr.generateInterpretedOutput(scopedHeap))
+            .collect(ImmutableList.toImmutableList())
+            .asList()
+    );
   }
 }

--- a/src/java/com/claro/intermediate_representation/expressions/StructFieldAccessExpr.java
+++ b/src/java/com/claro/intermediate_representation/expressions/StructFieldAccessExpr.java
@@ -5,6 +5,7 @@ import com.claro.intermediate_representation.types.BaseType;
 import com.claro.intermediate_representation.types.ClaroTypeException;
 import com.claro.intermediate_representation.types.Type;
 import com.claro.intermediate_representation.types.Types;
+import com.claro.intermediate_representation.types.impls.builtins_impls.structs.ClaroStruct;
 import com.google.common.collect.ImmutableList;
 
 import java.util.function.Supplier;
@@ -53,5 +54,13 @@ public class StructFieldAccessExpr extends Expr {
     exprCodegen.javaSourceBody().setLength(0);
 
     return exprCodegen.createMerged(res);
+  }
+
+  @Override
+  public Object generateInterpretedOutput(ScopedHeap scopedHeap) {
+    ClaroStruct exprStruct = (ClaroStruct) this.expr.generateInterpretedOutput(scopedHeap);
+    return exprStruct.values[
+        ((Types.StructType) exprStruct.getClaroType()).getFieldNames().indexOf(this.fieldName)
+        ];
   }
 }

--- a/src/java/com/claro/intermediate_representation/expressions/StructFieldAccessExpr.java
+++ b/src/java/com/claro/intermediate_representation/expressions/StructFieldAccessExpr.java
@@ -48,7 +48,16 @@ public class StructFieldAccessExpr extends Expr {
     GeneratedJavaSource exprCodegen = this.expr.generateJavaSourceOutput(scopedHeap);
     GeneratedJavaSource res =
         GeneratedJavaSource.forJavaSourceBody(
-            new StringBuilder().append(exprCodegen.javaSourceBody().toString()).append(".").append(this.fieldName));
+            new StringBuilder()
+                .append(this.codegenForRead ? "((" + this.validatedStructType.getFieldTypes()
+                    .get(fieldIndex)
+                    .getJavaSourceType() + ") " : "")
+                .append(exprCodegen.javaSourceBody().toString())
+                .append(".values[")
+                .append(fieldIndex)
+                .append("]")
+                .append(this.codegenForRead ? ")" : "")
+        );
 
     // Already consumed this java source above.
     exprCodegen.javaSourceBody().setLength(0);

--- a/src/java/com/claro/intermediate_representation/statements/MatchStmt.java
+++ b/src/java/com/claro/intermediate_representation/statements/MatchStmt.java
@@ -882,8 +882,7 @@ public class MatchStmt extends Stmt {
         break;
       case STRUCT:
         elementTypes_OUT_PARAM.set(((Types.StructType) matchedExprType).getFieldTypes());
-        getElementAccessPattern_OUT_PARAM.set(
-            (type, i) -> "%s." + ((Types.StructType) matchedExprType).getFieldNames().get(i));
+        getElementAccessPattern_OUT_PARAM.set((type, i) -> "((" + type.getJavaSourceType() + ") %s.values[" + i + "])");
         break;
       case USER_DEFINED_TYPE:
         HashMap<Type, Type> userDefinedConcreteTypeParamsMap = Maps.newHashMap();

--- a/src/java/com/claro/intermediate_representation/types/BUILD
+++ b/src/java/com/claro/intermediate_representation/types/BUILD
@@ -36,8 +36,14 @@ java_library(
 )
 
 java_library(
-    name = "polymorphic_type",
-    srcs = ["PolymorphicType.java"],
+    name = "parameterized_type",
+    srcs = ["ParameterizedType.java"],
+    deps = [
+        ":base_type",
+        ":type",
+        "//:autovalue",
+        "//:guava",
+    ],
 )
 
 java_library(
@@ -47,7 +53,7 @@ java_library(
         ":base_type",
         ":concrete_type",
         ":concrete_types",
-        ":polymorphic_type",
+        ":parameterized_type",
         ":supports_mutable_variant",
         ":type",
         ":type_provider",

--- a/src/java/com/claro/intermediate_representation/types/ParameterizedType.java
+++ b/src/java/com/claro/intermediate_representation/types/ParameterizedType.java
@@ -1,0 +1,11 @@
+package com.claro.intermediate_representation.types;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
+
+@AutoValue
+abstract class ParameterizedType extends Type {
+  public static ParameterizedType create(BaseType baseType, ImmutableMap<String, Type> parameterizedTypeArgs) {
+    return new AutoValue_ParameterizedType(baseType, parameterizedTypeArgs);
+  }
+}

--- a/src/java/com/claro/intermediate_representation/types/PolymorphicType.java
+++ b/src/java/com/claro/intermediate_representation/types/PolymorphicType.java
@@ -1,7 +1,0 @@
-package com.claro.intermediate_representation.types;
-
-// This interface represents any builtin Claro Type that is semantically "polymorphic" by nature, but will need to be
-// converted to a monomorphic runtime representation for both efficiency and (TODO) simple runtime type introspection.
-public interface PolymorphicType {
-  String getConcreteJavaClassRepresentation();
-}

--- a/src/java/com/claro/intermediate_representation/types/Types.java
+++ b/src/java/com/claro/intermediate_representation/types/Types.java
@@ -503,7 +503,7 @@ public final class Types {
     // the concrete struct variants of this semantically polymorphic type.
     public static HashMap<String, Types.StructType>
         allReferencedConcreteStructTypesToOptionalGenericTypeMappings = Maps.newHashMap();
-    public Optional<Map<Type, Type>> autoValueIgnored_concreteTypeMappings = Optional.empty();
+    private Optional<Map<Type, Type>> autoValueIgnored_concreteTypeMappings = Optional.empty();
 
     public static StructType forFieldTypes(ImmutableList<String> fieldNames, ImmutableList<Type> fieldTypes, boolean isMutable) {
       return new AutoValue_Types_StructType(BaseType.STRUCT, ImmutableMap.of(), fieldNames, fieldTypes, isMutable);

--- a/src/java/com/claro/intermediate_representation/types/Types.java
+++ b/src/java/com/claro/intermediate_representation/types/Types.java
@@ -621,7 +621,7 @@ public final class Types {
       $GenericTypeParam.concreteTypeMappingsForParameterizedTypeCodegen = this.autoValueIgnored_concreteTypeMappings;
       String concreteClassName = this.getJavaSourceType();
       StringBuilder res =
-          new StringBuilder("final class /*")
+          new StringBuilder("class /*")
               .append(this.toString())
               .append("*/ ")
               .append(concreteClassName)

--- a/src/java/com/claro/intermediate_representation/types/Types.java
+++ b/src/java/com/claro/intermediate_representation/types/Types.java
@@ -501,9 +501,8 @@ public final class Types {
 
     // Track all structs defined in the overall program. This will be used to codegen the relevant classes to represent
     // the concrete struct variants of this semantically polymorphic type.
-    public static HashMap<String, Types.StructType>
+    public static HashMap<StructType, Optional<Map<Type, Type>>>
         allReferencedConcreteStructTypesToOptionalGenericTypeMappings = Maps.newHashMap();
-    private Optional<Map<Type, Type>> autoValueIgnored_concreteTypeMappings = Optional.empty();
 
     public static StructType forFieldTypes(ImmutableList<String> fieldNames, ImmutableList<Type> fieldTypes, boolean isMutable) {
       return new AutoValue_Types_StructType(BaseType.STRUCT, ImmutableMap.of(), fieldNames, fieldTypes, isMutable);
@@ -524,20 +523,12 @@ public final class Types {
 
     @Override
     public String getJavaSourceType() {
-      String res =
-          String.format(
-              "$ClaroStruct_%s",
-              Hashing.sha256().hashUnencodedChars(
-                  this.getFieldTypes().stream()
-                      .map(Type::getJavaSourceType)
-                      .collect(Collectors.joining(", ", "<", ">")))
-          );
       // Any StructType that makes it to JavaSource codegen must have been a concrete type that needs a monomorphic
       // representation to be generated. We may require the mapping of generic -> concrete types for later codegen so
       // hold onto that here.
-      allReferencedConcreteStructTypesToOptionalGenericTypeMappings.put(res, this);
-      this.autoValueIgnored_concreteTypeMappings = $GenericTypeParam.concreteTypeMappingsForParameterizedTypeCodegen;
-      return res;
+      allReferencedConcreteStructTypesToOptionalGenericTypeMappings.put(
+          this, $GenericTypeParam.concreteTypeMappingsForParameterizedTypeCodegen);
+      return String.format("$ClaroStruct_%s", Hashing.sha256().hashUnencodedChars(this.toString()));
     }
 
     @Override
@@ -611,7 +602,8 @@ public final class Types {
     @Override
     public String getConcreteJavaClassRepresentation() {
       // Configure generic type mappings before codegen to ensure the concrete types are used.
-      $GenericTypeParam.concreteTypeMappingsForParameterizedTypeCodegen = this.autoValueIgnored_concreteTypeMappings;
+      $GenericTypeParam.concreteTypeMappingsForParameterizedTypeCodegen =
+          allReferencedConcreteStructTypesToOptionalGenericTypeMappings.get(this);
       String concreteClassName = this.getJavaSourceType();
       StringBuilder res =
           new StringBuilder("class /*")

--- a/src/java/com/claro/intermediate_representation/types/Types.java
+++ b/src/java/com/claro/intermediate_representation/types/Types.java
@@ -527,13 +527,10 @@ public final class Types {
       String res =
           String.format(
               "$ClaroStruct_%s",
-              // Must hash this synthetically generated string that contains field names and the RESOLVED CONCRETE types
-              // rather than deferring to the existing toString() because that one won't resolve Generic type mappings.
               Hashing.sha256().hashUnencodedChars(
-                  IntStream.range(0, this.getFieldTypes().size()).boxed()
-                      .map(i -> String.format(
-                          "%s = %s", this.getFieldNames().get(i), this.getFieldTypes().get(i).getJavaSourceType()))
-                      .collect(Collectors.joining(", ", "{", "}")))
+                  this.getFieldTypes().stream()
+                      .map(Type::getJavaSourceType)
+                      .collect(Collectors.joining(", ", "<", ">")))
           );
       // Any StructType that makes it to JavaSource codegen must have been a concrete type that needs a monomorphic
       // representation to be generated. We may require the mapping of generic -> concrete types for later codegen so

--- a/src/java/com/claro/intermediate_representation/types/impls/builtins_impls/structs/BUILD
+++ b/src/java/com/claro/intermediate_representation/types/impls/builtins_impls/structs/BUILD
@@ -1,0 +1,17 @@
+package(
+    default_visibility = [
+        "//visibility:public",
+    ]
+)
+
+
+java_library(
+    name = "structs",
+    srcs = glob(["*.java"]),
+    deps = [
+        "//src/java/com/claro/intermediate_representation/types:base_type",
+        "//src/java/com/claro/intermediate_representation/types:type",
+        "//src/java/com/claro/intermediate_representation/types:types",
+        "//src/java/com/claro/intermediate_representation/types/impls/builtins_impls:builtins_impls",
+    ],
+)

--- a/src/java/com/claro/intermediate_representation/types/impls/builtins_impls/structs/ClaroStruct.java
+++ b/src/java/com/claro/intermediate_representation/types/impls/builtins_impls/structs/ClaroStruct.java
@@ -1,0 +1,65 @@
+package com.claro.intermediate_representation.types.impls.builtins_impls.structs;
+
+import com.claro.intermediate_representation.types.Type;
+import com.claro.intermediate_representation.types.Types;
+import com.claro.intermediate_representation.types.impls.builtins_impls.ClaroBuiltinTypeImplementation;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ClaroStruct implements ClaroBuiltinTypeImplementation {
+
+  private final Types.StructType structType;
+  public final Object[] values;
+
+  public ClaroStruct(Types.StructType structType, Object... values) {
+    this.structType = structType;
+    this.values = values;
+  }
+
+  @Override
+  public Type getClaroType() {
+    return this.structType;
+  }
+
+  @Override
+  public String toString() {
+    return IntStream.range(0, this.values.length)
+        .boxed()
+        .map(
+            i ->
+                String.format(
+                    "%s = %s",
+                    this.structType.getFieldNames().get(i),
+                    this.values[i]
+                ))
+        .collect(Collectors.joining(", ", (this.structType.isMutable() ? "mut " : "") + "{", "}"));
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof ClaroStruct)) {
+      return false;
+    }
+    ClaroStruct otherStruct = (ClaroStruct) obj;
+    if (!this.structType.equals(otherStruct.structType)) {
+      return false;
+    }
+    for (int i = 0; i < this.values.length; ++i) {
+      if (!this.values[i].equals(otherStruct.values[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int hashCode = 1;
+    hashCode = 31 * hashCode + this.structType.hashCode();
+    hashCode = 31 * hashCode + Arrays.hashCode(this.values);
+
+    return hashCode;
+  }
+}

--- a/src/java/com/claro/runtime_utilities/BUILD
+++ b/src/java/com/claro/runtime_utilities/BUILD
@@ -16,6 +16,7 @@ java_library(
         "//src/java/com/claro/intermediate_representation/types:type",
         "//src/java/com/claro/intermediate_representation/types:types",
         "//src/java/com/claro/intermediate_representation/types/impls:claro_type_implementation",
+        "//src/java/com/claro/intermediate_representation/types/impls/builtins_impls/structs",
         "//src/java/com/claro/intermediate_representation/types/impls/user_defined_impls",
     ],
 )

--- a/src/java/com/claro/runtime_utilities/ClaroRuntimeUtilities.java
+++ b/src/java/com/claro/runtime_utilities/ClaroRuntimeUtilities.java
@@ -2,7 +2,10 @@ package com.claro.runtime_utilities;
 
 import com.claro.intermediate_representation.types.*;
 import com.claro.intermediate_representation.types.impls.ClaroTypeImplementation;
+import com.claro.intermediate_representation.types.impls.builtins_impls.structs.ClaroStruct;
+import com.claro.intermediate_representation.types.impls.user_defined_impls.$UserDefinedType;
 import com.claro.stdlib.StdLibModuleRegistry;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;

--- a/src/java/com/claro/runtime_utilities/ClaroRuntimeUtilities.java
+++ b/src/java/com/claro/runtime_utilities/ClaroRuntimeUtilities.java
@@ -176,4 +176,81 @@ public class ClaroRuntimeUtilities {
       }
     }
   }
+
+  public static $UserDefinedType<ClaroStruct> $getErrorParsedJson(Type targetType, String jsonPathError, String jsonString) {
+    final Types.StructType parsedJsonStructType =
+        Types.StructType.forFieldTypes(
+            ImmutableList.of("result", "rawJson"),
+            ImmutableList.of(
+                Types.OneofType.forVariantTypes(
+                    ImmutableList.of(
+                        targetType,
+                        Types.UserDefinedType.forTypeNameAndParameterizedTypes(
+                            "Error",
+                            /*definingModuleDisambiguator=*/StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR,
+                            ImmutableList.of(Types.STRING)
+                        )
+                    )
+                ),
+                Types.STRING
+            ),
+            /*isMutable=*/false
+        );
+
+    return new $UserDefinedType<>(
+        "ParsedJson",
+        /*definingModuleDisambiguator=*/StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR,
+        ImmutableList.of(targetType),
+        parsedJsonStructType,
+        new ClaroStruct(
+            parsedJsonStructType,
+            new $UserDefinedType<>(
+                "Error",
+                /*definingModuleDisambiguator=*/StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR,
+                ImmutableList.of(Types.STRING),
+                Types.STRING,
+                String.format(
+                    "Given JSON string did not match the asserted target type definition.\n" +
+                    "\tExpected:\n" +
+                    "\t\t%s\n" +
+                    "\tAt JsonPath:\n" +
+                    "\t\t%s",
+                    targetType,
+                    jsonPathError
+                )
+            ),
+            jsonString
+        )
+    );
+  }
+
+  public static $UserDefinedType<ClaroStruct> $getSuccessParsedJson(
+      Type targetType, Object parsedRes, String jsonString) {
+    final Types.StructType parsedJsonStructType =
+        Types.StructType.forFieldTypes(
+            ImmutableList.of("result", "rawJson"),
+            ImmutableList.of(
+                Types.OneofType.forVariantTypes(
+                    ImmutableList.of(
+                        targetType,
+                        Types.UserDefinedType.forTypeNameAndParameterizedTypes(
+                            "Error",
+                            /*definingModuleDisambiguator=*/StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR,
+                            ImmutableList.of(Types.STRING)
+                        )
+                    )
+                ),
+                Types.STRING
+            ),
+            /*isMutable=*/false
+        );
+
+    return new $UserDefinedType<>(
+        "ParsedJson",
+        /*definingModuleDisambiguator=*/StdLibModuleRegistry.STDLIB_MODULE_DISAMBIGUATOR,
+        ImmutableList.of(targetType),
+        parsedJsonStructType,
+        new ClaroStruct(parsedJsonStructType, parsedRes, jsonString)
+    );
+  }
 }

--- a/src/java/com/claro/runtime_utilities/http/$ClaroHttpServer.java
+++ b/src/java/com/claro/runtime_utilities/http/$ClaroHttpServer.java
@@ -16,7 +16,6 @@ import io.activej.promise.SettablePromise;
 
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -113,15 +112,6 @@ class $ClaroHttpEndpointResultHandler implements FutureCallback<$ClaroHttpRespon
     promise.set(
         HttpResponse.ofCode(500)
             .withPlainText(
-                "Unhandled Runtime Exception in Http Endpoint Handler!\n" + throwable.getMessage() + "\n\n" +
-                Arrays.toString(throwable.getStackTrace()) + "\n\nCaused by:\n" +
-                Arrays.toString(ultimateCause(throwable).getStackTrace())));
-  }
-
-  private Throwable ultimateCause(Throwable throwable) {
-    if (throwable.getCause() == null) {
-      return throwable;
-    }
-    return ultimateCause(throwable.getCause());
+                "Unhandled Runtime Exception in Http Endpoint Handler!\n" + throwable));
   }
 }


### PR DESCRIPTION
Unfortunately, there is not currently time to fully commit going down this road of migrating Claro's nested types to be codegen'd to use concrete classes that fully specify their runtime types. As I'm reaching the end of my year of full time work on Claro this is just a more pervasive change than I actually have time to work through for now. At the moment it's a much higher priority to truly work through documenting the current state of Claro than trying to work through this more idealized approach to more efficient runtime characteristics. 

# Oversight in Original Planning
I can't just leave things partially migrated to using this approach, as this is something of an all or nothing change. In particular, Claro's type system is designed to allow the following: 
```
var nestedOneof: tuple<oneof<int, string>, int> = (10, 10); 
```

Currently, Claro's unable to correctly codegen the rhs initialization as `tuple<oneof<int, string>, int>` and will instead codegen as `tuple<int, int>` because the LHS asserted type is not being used to override the implied type of the RHS for the sake of codegen. This is certainly something that can be worked around, but in my estimation would (in combination with the remaining migration of struct, list, map and user-defined-type) take so much time that I would lose my opportunity to put sufficient effort into documentation that this project needs more than anything at this point in time.

# Maintaining history
I'm intentionally reverting these commits in order to maintain the history so that I can potentially revisit these changes to make redoing this at some point in the future easier. 