### PR TITLE
Issue #50 fix

### DIFF
--- a/src/java/com/claro/ClaroParser.cup
+++ b/src/java/com/claro/ClaroParser.cup
@@ -3915,7 +3915,7 @@ http_endpoints_list ::=
        LexedValue<ImmutableList<ImmutableList.Builder>> fsLexedValue = (LexedValue<ImmutableList<ImmutableList.Builder>>) path.value;
        ImmutableList<ImmutableList.Builder> fs = fsLexedValue.getVal();
        FormatStringExpr pathFmtStringExpr = new FormatStringExpr(fs.get(0).build().reverse(), fs.get(1).build().reverse(), fsLexedValue.getCurrentInputLine(), path.right, path.left, path.left + fsLexedValue.getLen());
-
+       
        RESULT = tail.put(endpoint_name, pathFmtStringExpr);
     :}
   | identifier:endpoint_name COLON STRING:path COMMA http_endpoints_list:tail
@@ -3933,6 +3933,20 @@ http_endpoints_list ::=
   | identifier:endpoint_name COLON STRING:path
     {:
        RESULT = ImmutableMap.<IdentifierReferenceTerm, Object>builder().put(endpoint_name, path.getVal());
+    :}
+  | identifier:endpoint_name COLON fmt_string:path COMMA:c 
+  | identifier:endpoint_name COLON STRING:path COMMA:c
+    {: 
+      Symbol currSymbol = new Symbol(
+          -1,
+          cleft,
+          cright,
+          LexedValue.create(
+            (TypeProvider) ImmediateTypeProvider.of(Types.INTEGER),
+            c.getCurrentInputLine(),
+            c.getLen())
+       );
+      report_error("Syntax error: Unexpected comma", currSymbol);
     :}
   ;
 

--- a/src/java/com/claro/ClaroParser.cup
+++ b/src/java/com/claro/ClaroParser.cup
@@ -3934,7 +3934,21 @@ http_endpoints_list ::=
     {:
        RESULT = ImmutableMap.<IdentifierReferenceTerm, Object>builder().put(endpoint_name, path.getVal());
     :}
+
+  /*Report on unexpected trailing commas.*/
   | identifier:endpoint_name COLON fmt_string:path COMMA:c 
+    {: 
+      Symbol currSymbol = new Symbol(
+          -1,
+          cleft,
+          cright,
+          LexedValue.create(
+            String.valueOf(c.getVal()),
+            c.getCurrentInputLine(),
+            c.getLen())
+       );
+      report_error("Syntax error: Unexpected trailing comma", currSymbol);
+    :}
   | identifier:endpoint_name COLON STRING:path COMMA:c
     {: 
       Symbol currSymbol = new Symbol(
@@ -3942,11 +3956,11 @@ http_endpoints_list ::=
           cleft,
           cright,
           LexedValue.create(
-            (TypeProvider) ImmediateTypeProvider.of(Types.INTEGER),
+            String.valueOf(c.getVal()),
             c.getCurrentInputLine(),
             c.getLen())
        );
-      report_error("Syntax error: Unexpected comma", currSymbol);
+      report_error("Syntax error: Unexpected trailing comma", currSymbol);
     :}
   ;
 

--- a/src/java/com/claro/ClaroParser.cup
+++ b/src/java/com/claro/ClaroParser.cup
@@ -3915,7 +3915,7 @@ http_endpoints_list ::=
        LexedValue<ImmutableList<ImmutableList.Builder>> fsLexedValue = (LexedValue<ImmutableList<ImmutableList.Builder>>) path.value;
        ImmutableList<ImmutableList.Builder> fs = fsLexedValue.getVal();
        FormatStringExpr pathFmtStringExpr = new FormatStringExpr(fs.get(0).build().reverse(), fs.get(1).build().reverse(), fsLexedValue.getCurrentInputLine(), path.right, path.left, path.left + fsLexedValue.getLen());
-       
+
        RESULT = tail.put(endpoint_name, pathFmtStringExpr);
     :}
   | identifier:endpoint_name COLON STRING:path COMMA http_endpoints_list:tail


### PR DESCRIPTION
Attempting to fix #50 

Using this you now get a more helpful error position with a trailing comma.

For example
```
HttpService Server {
  rootEndpoint: "/",
}
```

Will output
```
server.claro:2: Unexpected token <com.claro.intermediate_representation.types.TypeProvider$ImmediateTypeProvider@475c9c31>
  rootEndpoint: "/",
                   ^
          ```